### PR TITLE
Make updated_at the default sort for app and dashboard pages

### DIFF
--- a/laravel/app/Http/Controllers/ApplicationController.php
+++ b/laravel/app/Http/Controllers/ApplicationController.php
@@ -31,11 +31,11 @@ class ApplicationController extends Controller
         {
             if(in_array($this->auth->user()->role, ['admin']))
             {
-                $applications = Application::orderBy('total_score', 'desc')->get();
+                $applications = Application::orderBy('updated_at', 'asc')->get();
             }
             elseif(in_array($this->auth->user()->role, ['judge', 'observer']))
             {
-                $applications = Application::whereIn('status', ['submitted', 'review'])->orderBy('total_score', 'desc')->get();
+                $applications = Application::whereIn('status', ['submitted', 'review'])->orderBy('updated_at', 'asc')->get();
             }
             else
             {

--- a/laravel/app/Http/Controllers/PageController.php
+++ b/laravel/app/Http/Controllers/PageController.php
@@ -24,7 +24,7 @@ class PageController extends Controller
         {
             if(in_array($this->auth->user()->role, ['judge', 'observer']))
             {
-                $applications = Application::whereIn('status', ['submitted', 'review'])->get();
+                $applications = Application::whereIn('status', ['submitted', 'review'])->orderBy('updated_at', 'asc')->get();
             }
             else
             {


### PR DESCRIPTION
The application page was sorting by scores, which made the page
different on every refresh and cause problems while judges were
scoring. Until we have sortable columns, make the update_at the
default sort, which is the submission time.

Signed-off-by: Marc Jones <marcj303@gmail.com>