### PR TITLE
Make judges dashboard a "worklist"

### DIFF
--- a/laravel/app/Http/Controllers/PageController.php
+++ b/laravel/app/Http/Controllers/PageController.php
@@ -24,13 +24,17 @@ class PageController extends Controller
         {
             if(in_array($this->auth->user()->role, ['judge', 'observer']))
             {
-                $applications = Application::whereIn('status', ['submitted', 'review'])->orderBy('updated_at', 'asc')->get();
+                // Get all applications where the application is submitted and the judge has not submitted a score(judged).
+                $applications = Application::whereIn('applications.status', ['submitted', 'review'])
+                    ->leftJoin('judged', 'judged.application_id', '=', 'applications.id')
+                    ->whereNull('judged.user_id')
+                    ->orderBy('applications.updated_at', 'asc')
+                    ->get(['applications.*']);
             }
             else
             {
                 $applications = $this->auth->user()->applications;
             }
-
             $rounds = Round::orderBy('start_date', 'desc')->get();
             return view('pages/dashboard', compact('applications', 'ongoing', 'upcoming', 'rounds'));
         }


### PR DESCRIPTION
Only show the applications that need to be judged on the
judges dashboard. A list of applications is availble on
the applications and scores views.

On the technical side, this is done with a left outer join
of the applications table with the judges table when the
judges table is NULL.

Signed-off-by: Marc Jones <marcj303@gmail.com>